### PR TITLE
Add useQueryParams option

### DIFF
--- a/routable_annotations/lib/routable_annotations.dart
+++ b/routable_annotations/lib/routable_annotations.dart
@@ -7,6 +7,7 @@ class Routable {
   final Type? extra;
   final Type? transition;
   final bool useParams;
+  final bool useQueryParams;
   const Routable({
     required this.path,
     this.on,
@@ -14,6 +15,7 @@ class Routable {
     this.useParams = false,
     this.isProtected = false,
     this.transition,
+    this.useQueryParams = false,
   });
 }
 

--- a/routable_annotations/pubspec.yaml
+++ b/routable_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: routable_annotations
 description: "A package containing the necessary annotations for `routable_builder`"
-version: 0.1.1
+version: 0.2.0
 homepage: "https://github.com/WeAreAthlon/routable"
 
 environment:


### PR DESCRIPTION
I added support in `routable_builder` for `state.uri.queryParameters` because that is where apparently the `?token` comes and I simplified a bunch of code in Nexton, removed some hacks and it works.