### PR TITLE
Add implementation for useQueryParams to Routable builder

### DIFF
--- a/routable_builder/CHANGELOG.md
+++ b/routable_builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.2.0
+
+- Add implementation for `useQueryParams` to `Routable` builder
+
 ## 0.1.1
 
 - Update documentation

--- a/routable_builder/README.md
+++ b/routable_builder/README.md
@@ -152,6 +152,26 @@ class ProductPage extends StatelessWidget {
 Routes.product.push(context, Product(id: 'item_id'));
 ```
 
+```dart
+@Routable(path: '/search', useQueryParams: true)
+class SearchPage extends StatelessWidget {
+  final Map<String, String>? queryParams;
+
+  SearchPage({this.queryParams});
+
+  ...
+}
+
+// Generated GoRoute for SearchPage
+GoRoute(
+  path: '/search',
+  pageBuilder: (context, state) => MaterialPage(
+    child: SearchPage(queryParams: state.uri.queryParameters),
+  ),
+),
+```
+
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/routable_builder/lib/routable_builder.dart
+++ b/routable_builder/lib/routable_builder.dart
@@ -32,11 +32,11 @@ class ConfigGenerator extends GeneratorForAnnotation<RouteConfig> {
     final a = <Map>[];
     for (final entry in v.entries) {
       final rec = data.firstWhere((e) {
-        final avilable = e['name'] == entry.key;
+        final available = e['name'] == entry.key;
         final on = (e['on'] != null && parent != null)
             ? e['on'] == parent['name']
             : true;
-        return avilable && on;
+        return available && on;
       });
       final path =
           parent != null ? rec["path"].replaceFirst('/', '') : rec["path"];

--- a/routable_builder/lib/routable_builder.dart
+++ b/routable_builder/lib/routable_builder.dart
@@ -28,21 +28,21 @@ class ConfigGenerator extends GeneratorForAnnotation<RouteConfig> {
   }
 
   // Function to convert a simple node into the desired record format.
-  List<Map> record(Map v, List<Map> data, [Map? parrent]) {
+  List<Map> record(Map v, List<Map> data, [Map? parent]) {
     final a = <Map>[];
     for (final entry in v.entries) {
       final rec = data.firstWhere((e) {
         final avilable = e['name'] == entry.key;
-        final on = (e['on'] != null && parrent != null)
-            ? e['on'] == parrent['name']
+        final on = (e['on'] != null && parent != null)
+            ? e['on'] == parent['name']
             : true;
         return avilable && on;
       });
       final path =
-          parrent != null ? rec["path"].replaceFirst('/', '') : rec["path"];
+          parent != null ? rec["path"].replaceFirst('/', '') : rec["path"];
       final current = {
         ...rec,
-        "full_path": [if (parrent != null) parrent["full_path"], path]
+        "full_path": [if (parent != null) parent["full_path"], path]
             .join("/")
             .replaceFirst('//', '/'),
         "path": path,

--- a/routable_builder/lib/routable_builder.dart
+++ b/routable_builder/lib/routable_builder.dart
@@ -1,4 +1,4 @@
-library injector_builder;
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/routable_builder/pubspec.yaml
+++ b/routable_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: routable_builder
 description: "Routable is a package that provides code generation for routing in Flutter applications"
-version: 0.1.2
+version: 0.2.0
 homepage: "https://github.com/WeAreAthlon/routable"
 
 environment:
@@ -16,7 +16,7 @@ dependencies:
   glob: ^2.1.2
   source_gen: ^1.5.0
 
-  routable_annotations: ^0.1.0
+  routable_annotations: ^0.2.0
   # path: ../routable_annotations
 
 dev_dependencies:


### PR DESCRIPTION
Adds the imlementation for the interface that was brought in with #2. 
The code basically just adds this:

```dart
queryParams: state.uri.queryParameters,
```

The reason why we need this is because that is the **only** way to get the `?token=` and such parameters, from the `uri` object whilst still using the default deep linking behaviour
