### PR TITLE
API change, private guard now takes a callback

### DIFF
--- a/routable_builder/CHANGELOG.md
+++ b/routable_builder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 1.0.0
+
+- **BREAKING CHANGE** 
+  - `authenticated` parameter in `Routable` builder is now a `Future<bool> Function()` instead of `Future<bool>` to remove dependency on rebuilding `GoRouter`
+
 ## 0.2.0
 
 - Add implementation for `useQueryParams` to `Routable` builder

--- a/routable_builder/lib/routable_builder.dart
+++ b/routable_builder/lib/routable_builder.dart
@@ -163,9 +163,9 @@ GoRoute(
 ${imports.map((import) => "import '$import';").join("\n")}
 
 FutureOr<String?> Function(BuildContext, GoRouterState) _privateGuard(
-        Future<bool> authenticated) =>
+        Future<bool> Function() authenticated) =>
   (context, state) async {
-    final isAuthenticated = await authenticated;
+    final isAuthenticated = await authenticated();
 
     if (!isAuthenticated) return "$unauthenticatedPath";
     return null;
@@ -204,7 +204,7 @@ extension UriExtension on Uri {
   }
 }
 
-\$buildRoutes(Future<bool> authenticated) => [
+List<GoRoute>\$buildRoutes(Future<bool> Function() authenticated) => [
   ${result.map(buildRoute).join("\n")}
 ];
 """;

--- a/routable_builder/pubspec.yaml
+++ b/routable_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: routable_builder
 description: "Routable is a package that provides code generation for routing in Flutter applications"
-version: 0.2.0
+version: 1.0.0
 homepage: "https://github.com/WeAreAthlon/routable"
 
 environment:


### PR DESCRIPTION
## What?
This change modifies the `_privateGuard` function to take a callback instead of just a promise. This is a **breaking** change. 

## Why?

In Nexton, a project that uses this, it was discovered that the `GoRouter` should not be rebuilt under any circumstances due to an issue where it would reopen a deep link because it would lose the state. The problem is that this library relies on us rebuilding the `$buildRoutes` function with a new promise, which is not possible unless we rebuild the `GoRouter`.

